### PR TITLE
Migrate from IronRDP fork to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "ironrdp-pdu",
  "ironrdp-rdpsnd",
  "ironrdp-server",
+ "ironrdp-svc",
  "rcgen",
  "rdp-capture",
  "rdp-dbus",
@@ -4054,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-acceptor"
 version = "0.8.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
@@ -4067,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-ainput"
 version = "0.5.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bitflags 2.10.0",
  "ironrdp-core",
@@ -4079,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-async"
 version = "0.8.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bytes",
  "ironrdp-connector",
@@ -4091,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-cliprdr"
 version = "0.5.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bitflags 2.10.0",
  "ironrdp-core",
@@ -4103,7 +4104,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-connector"
 version = "0.8.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "ironrdp-core",
  "ironrdp-error",
@@ -4121,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-core"
 version = "0.1.5"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "ironrdp-error",
 ]
@@ -4129,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.5.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "ironrdp-core",
  "ironrdp-dvc",
@@ -4141,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-dvc"
 version = "0.5.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
@@ -4151,9 +4152,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-echo"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-egfx"
 version = "0.1.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bit_field",
  "bitflags 2.10.0",
@@ -4167,12 +4179,12 @@ dependencies = [
 [[package]]
 name = "ironrdp-error"
 version = "0.1.3"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 
 [[package]]
 name = "ironrdp-graphics"
 version = "0.7.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bit_field",
  "bitflags 2.10.0",
@@ -4188,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-pdu"
 version = "0.7.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bit_field",
  "bitflags 2.10.0",
@@ -4211,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.7.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bitflags 2.10.0",
  "ironrdp-core",
@@ -4223,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-server"
 version = "0.10.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4235,6 +4247,8 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
+ "ironrdp-echo",
+ "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-rdpsnd",
@@ -4253,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "ironrdp-svc"
 version = "0.6.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
  "bitflags 2.10.0",
  "ironrdp-core",
@@ -4263,9 +4277,8 @@ dependencies = [
 [[package]]
 name = "ironrdp-tokio"
 version = "0.8.0"
-source = "git+https://github.com/olafkfreund/cosmic-ext-IronRDP#6771a10951ae8232731517109535ffaa18c170e2"
+source = "git+https://github.com/Devolutions/IronRDP#9a1ac3092ee3eac3e81823349d8e027065f5b8f8"
 dependencies = [
- "bytes",
  "ironrdp-async",
  "ironrdp-connector",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "cosmic-ext-rdp-server"
 
 [workspace.package]
 version = "0.4.0"
-edition = "2021"
-rust-version = "1.85"
+edition = "2024"
+rust-version = "1.89"
 license = "GPL-3.0-only"
 repository = "https://github.com/olafkfreund/cosmic-ext-rdp-server"
 authors = ["Olaf K. Freund"]
@@ -37,15 +37,15 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 
-# RDP protocol (git fork with EGFX support)
-ironrdp-server = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP", features = ["helper"] }
-ironrdp-cliprdr = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-core = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-displaycontrol = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-pdu = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-rdpsnd = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-dvc = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
-ironrdp-egfx = { git = "https://github.com/olafkfreund/cosmic-ext-IronRDP" }
+# RDP protocol (upstream IronRDP with native EGFX support)
+ironrdp-server = { git = "https://github.com/Devolutions/IronRDP", features = ["helper", "egfx"] }
+ironrdp-cliprdr = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-core = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-displaycontrol = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-pdu = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-rdpsnd = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-dvc = { git = "https://github.com/Devolutions/IronRDP" }
+ironrdp-egfx = { git = "https://github.com/Devolutions/IronRDP" }
 
 # Async utilities
 async-trait = "0.1"

--- a/crates/cosmic-ext-rdp-broker/src/broker.rs
+++ b/crates/cosmic-ext-rdp-broker/src/broker.rs
@@ -224,10 +224,10 @@ pub async fn idle_cleanup_task(registry: SessionRegistry, idle_timeout_secs: u64
         let idle_users = registry.idle_sessions(idle_timeout_secs).await;
         for username in idle_users {
             tracing::info!(%username, "Idle timeout reached, terminating session");
-            if let Some(entry) = registry.remove(&username).await {
-                if let Err(e) = spawner::stop_user_server(&entry.unit_name).await {
-                    tracing::warn!(%username, "Failed to stop idle session: {e}");
-                }
+            if let Some(entry) = registry.remove(&username).await
+                && let Err(e) = spawner::stop_user_server(&entry.unit_name).await
+            {
+                tracing::warn!(%username, "Failed to stop idle session: {e}");
             }
         }
 

--- a/crates/cosmic-ext-rdp-server/Cargo.toml
+++ b/crates/cosmic-ext-rdp-server/Cargo.toml
@@ -28,6 +28,7 @@ ironrdp-pdu.workspace = true
 ironrdp-rdpsnd.workspace = true
 ironrdp-dvc.workspace = true
 ironrdp-egfx.workspace = true
+ironrdp-svc = { git = "https://github.com/Devolutions/IronRDP" }
 
 # Clipboard
 arboard.workspace = true

--- a/crates/cosmic-ext-rdp-server/src/clipboard.rs
+++ b/crates/cosmic-ext-rdp-server/src/clipboard.rs
@@ -250,7 +250,7 @@ impl CliprdrServerFactory for LocalClipboardFactory {}
 ///
 /// RDP clipboard text is always UTF-16LE with a null terminator.
 fn decode_utf16le_text(data: &[u8]) -> Option<String> {
-    if data.len() < 2 || data.len() % 2 != 0 {
+    if data.len() < 2 || !data.len().is_multiple_of(2) {
         return None;
     }
 

--- a/crates/cosmic-ext-rdp-server/src/egfx.rs
+++ b/crates/cosmic-ext-rdp-server/src/egfx.rs
@@ -8,37 +8,60 @@
 //!
 //! Three components share state via `SharedEgfx` (`Arc<Mutex<EgfxInner>>`):
 //!
-//! - [`EgfxBridge`] – implements [`DvcProcessor`] and sits inside the
-//!   DRDYNVC static virtual channel. Handles client↔server EGFX messages
-//!   (capability negotiation, frame acks). On detecting readiness, auto-creates
-//!   the surface and maps it to the output.
+//! - The upstream [`GfxDvcBridge`] – wraps `GraphicsPipelineServer` as a
+//!   `DvcProcessor` inside the DRDYNVC static virtual channel. Handles
+//!   client↔server EGFX messages (capability negotiation, frame acks).
 //!
 //! - [`EgfxController`] – public handle used by `LiveDisplayUpdates` to
-//!   check readiness, send H.264 frames, and obtain the DVC channel ID.
+//!   check readiness, send H.264 frames, and resize the surface.
 //!
-//! - [`EgfxEventSetter`] – lightweight handle used after `RdpServer`
-//!   construction to inject the server event sender into shared state.
+//! - [`CosmicGfxFactory`] – implements [`GfxServerFactory`] to create
+//!   the bridge/handler and receive the server event sender.
 
 use std::sync::{Arc, Mutex};
 
-use ironrdp_core::{encode_vec, impl_as_any, Encode, WriteCursor};
-use ironrdp_dvc::{DvcEncode, DvcMessage, DvcProcessor, DvcProcessorFactory, DvcServerProcessor};
+use ironrdp_core::encode_vec;
+use ironrdp_dvc::DvcMessage;
 use ironrdp_egfx::pdu::{Avc420Region, CapabilitiesAdvertisePdu, CapabilitySet};
 use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer};
-use ironrdp_pdu::PduResult;
-use ironrdp_server::ServerEvent;
+use ironrdp_server::{
+    EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle, ServerEvent,
+    ServerEventSender,
+};
+use ironrdp_svc::SvcMessage;
 use tokio::sync::mpsc;
 
 /// H.264 quantization parameter for EGFX AVC420 regions.
 /// Lower = better quality (18-23 is typical for RDP).
 const EGFX_QP: u8 = 22;
 
-/// Shared inner state between bridge, handler, and controller.
+/// Convert `Vec<DvcMessage>` (from `drain_output()`) to `Vec<SvcMessage>`
+/// for use with `EgfxServerMessage::SendMessages`.
+///
+/// `DvcMessage = Box<dyn DvcEncode>` and `SvcMessage` wraps `Box<dyn SvcEncode>`.
+/// Both trait bounds are `Encode + Send`, but they are separate traits, so we
+/// encode to bytes and wrap as `Vec<u8>` which implements `SvcEncode`.
+fn dvc_to_svc_messages(dvc_messages: Vec<DvcMessage>) -> Vec<SvcMessage> {
+    dvc_messages
+        .into_iter()
+        .filter_map(|msg: DvcMessage| {
+            match encode_vec(msg.as_ref()) {
+                Ok(bytes) => Some(SvcMessage::from(bytes)),
+                Err(e) => {
+                    tracing::error!(?e, "EGFX: failed to encode DVC message to SVC");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+/// Shared inner state between the GFX handler, controller, and factory.
 struct EgfxInner {
-    server: GraphicsPipelineServer,
+    /// Shared handle to the `GraphicsPipelineServer` (same one inside `GfxDvcBridge`).
+    server_handle: Option<GfxServerHandle>,
     ready: bool,
     surface_id: Option<u16>,
-    dvc_channel_id: Option<u32>,
     supports_avc420: bool,
     width: u16,
     height: u16,
@@ -59,229 +82,77 @@ fn lock_shared(shared: &SharedEgfx) -> std::sync::MutexGuard<'_, EgfxInner> {
     })
 }
 
-// --------------- ZGFX compression wrapper ---------------
+// --------------- GFX Handler (capability callbacks) ---------------
 
-/// ZGFX-wrapped DVC message.
-///
-/// Per MS-RDPEGFX, all EGFX messages over the DVC channel MUST be wrapped
-/// in ZGFX (`RDP_SEGMENTED_DATA`). Small payloads (≤ 65534 bytes) use the
-/// SINGLE descriptor (`0xE0`). Larger payloads MUST use MULTIPART (`0xE1`)
-/// because `FreeRDP` allocates a 65 536-byte output buffer per segment in
-/// `zgfx_decompress_segment`—exceeding this limit causes `status: -1`.
-struct ZgfxWrapped {
-    data: Vec<u8>,
-}
-
-impl Encode for ZgfxWrapped {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
-        dst.write_slice(&self.data);
-        Ok(())
-    }
-
-    fn name(&self) -> &'static str {
-        "ZgfxWrapped"
-    }
-
-    fn size(&self) -> usize {
-        self.data.len()
-    }
-}
-
-// SAFETY: ZgfxWrapped only contains a Vec<u8> which is Send.
-impl DvcEncode for ZgfxWrapped {}
-
-/// Maximum uncompressed data per ZGFX segment (excluding the 1-byte
-/// flags/type prefix). `FreeRDP`'s `zgfx_decompress_segment` uses a
-/// 65 536-byte output buffer, so each segment must decompress to at most
-/// that many bytes. The 1-byte `BulkEncodedData` header (`0x04`) is
-/// included in the segment size field, leaving 65 534 bytes for data.
-const ZGFX_MAX_SEGMENT_DATA: usize = 65534;
-
-/// Concatenate and ZGFX-wrap all outgoing EGFX DVC messages into a
-/// single DVC message.
-///
-/// Per MS-RDPEGFX §2.2.2, the server serialises all PDUs for a logical
-/// unit (e.g. `StartFrame` + `WireToSurface1` + `EndFrame`) into a single
-/// `RDP_SEGMENTED_DATA` payload. `FreeRDP`'s `rdpgfx_on_data_received()`
-/// calls `zgfx_decompress()` **once** on the reassembled DVC buffer and
-/// then iterates over the contained PDUs.
-///
-/// For payloads ≤ 65 534 bytes we emit a SINGLE segment (`0xE0`).
-/// For larger payloads we emit MULTIPART (`0xE1`) with 65 534-byte chunks.
-fn zgfx_wrap_messages(messages: &[DvcMessage]) -> Vec<DvcMessage> {
-    if messages.is_empty() {
-        return Vec::new();
-    }
-
-    // Concatenate all encoded EGFX PDUs into one byte buffer.
-    let mut combined = Vec::new();
-    for msg in messages {
-        match encode_vec(msg.as_ref()) {
-            Ok(raw) => {
-                tracing::trace!(
-                    encoded_len = raw.len(),
-                    "EGFX ZGFX: encoded inner PDU"
-                );
-                combined.extend_from_slice(&raw);
-            }
-            Err(e) => {
-                tracing::error!(?e, "EGFX ZGFX: failed to encode inner PDU, skipping");
-            }
-        }
-    }
-
-    let data = if combined.len() <= ZGFX_MAX_SEGMENT_DATA {
-        // Small payload: SINGLE segment [0xE0, flags|type, data...]
-        let mut buf = Vec::with_capacity(2 + combined.len());
-        buf.push(0xE0); // ZGFX_SEGMENTED_SINGLE
-        buf.push(0x04); // RDP8 type (0x4), uncompressed
-        buf.extend_from_slice(&combined);
-        buf
-    } else {
-        // Large payload: MULTIPART segments, each ≤ ZGFX_MAX_SEGMENT_DATA.
-        zgfx_build_multipart(&combined)
-    };
-
-    tracing::trace!(
-        pdu_count = messages.len(),
-        payload_len = combined.len(),
-        zgfx_len = data.len(),
-        multipart = combined.len() > ZGFX_MAX_SEGMENT_DATA,
-        "EGFX ZGFX: wrapped {} PDUs",
-        messages.len()
-    );
-
-    vec![Box::new(ZgfxWrapped { data }) as DvcMessage]
-}
-
-/// Build a ZGFX MULTIPART (`0xE1`) payload from raw uncompressed data.
-///
-/// Format (all integers little-endian):
-/// ```text
-/// 0xE1                              // descriptor
-/// segment_count  : u16              // number of segments
-/// uncompressed_size : u32           // total uncompressed output size
-/// for each segment:
-///   segment_size : u32              // size of BulkEncodedData (1 + data_len)
-///   0x04                            // flags|type: RDP8, uncompressed
-///   data[data_len]                  // raw PDU bytes for this segment
-/// ```
-fn zgfx_build_multipart(payload: &[u8]) -> Vec<u8> {
-    let chunks: Vec<&[u8]> = payload.chunks(ZGFX_MAX_SEGMENT_DATA).collect();
-
-    #[allow(clippy::cast_possible_truncation)]
-    let segment_count = chunks.len() as u16;
-    #[allow(clippy::cast_possible_truncation)]
-    let uncompressed_size = payload.len() as u32;
-
-    // Header: 1 (descriptor) + 2 (count) + 4 (uncomp size)
-    // Per segment: 4 (seg size) + 1 (flags) + data_len
-    let total_size = 7 + chunks.iter().map(|c| 5 + c.len()).sum::<usize>();
-    let mut buf = Vec::with_capacity(total_size);
-
-    buf.push(0xE1); // ZGFX_SEGMENTED_MULTIPART
-    buf.extend_from_slice(&segment_count.to_le_bytes());
-    buf.extend_from_slice(&uncompressed_size.to_le_bytes());
-
-    for chunk in &chunks {
-        #[allow(clippy::cast_possible_truncation)]
-        let seg_size = (1 + chunk.len()) as u32; // 1 byte flags + data
-        buf.extend_from_slice(&seg_size.to_le_bytes());
-        buf.push(0x04); // RDP8 type (0x4), uncompressed
-        buf.extend_from_slice(chunk);
-    }
-
-    buf
-}
-
-// --------------- Bridge (DvcProcessor) ---------------
-
-/// Wraps `GraphicsPipelineServer` as a DVC processor, with automatic
-/// surface creation on readiness.
+/// Handler that detects EGFX readiness and auto-creates surfaces.
 ///
 /// When the client's `CapabilitiesAdvertise` is processed and the server
-/// transitions to ready, this bridge auto-creates a surface at the current
+/// transitions to ready, this handler creates a surface at the current
 /// display dimensions and maps it to output origin (0, 0).
-pub struct EgfxBridge {
+struct CosmicGfxHandler {
     shared: SharedEgfx,
 }
 
-impl_as_any!(EgfxBridge);
-
-impl DvcProcessor for EgfxBridge {
-    #[allow(clippy::unnecessary_literal_bound)]
-    fn channel_name(&self) -> &str {
-        "Microsoft::Windows::RDS::Graphics"
+impl GraphicsPipelineHandler for CosmicGfxHandler {
+    fn capabilities_advertise(&mut self, _pdu: &CapabilitiesAdvertisePdu) {
+        tracing::debug!("EGFX: client advertised capabilities");
     }
 
-    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
-        tracing::info!(channel_id, "EGFX: DVC channel opened");
+    fn on_ready(&mut self, negotiated: &CapabilitySet) {
+        tracing::info!(?negotiated, "EGFX: channel ready");
         let mut inner = lock_shared(&self.shared);
-        inner.dvc_channel_id = Some(channel_id);
-        inner.server.start(channel_id).map(|msgs| zgfx_wrap_messages(&msgs))
-    }
+        inner.ready = true;
+        inner.supports_avc420 = true; // V8_1 with AVC420 was negotiated if ready
 
-    fn close(&mut self, channel_id: u32) {
-        tracing::info!("EGFX: DVC channel closed");
-        let mut inner = lock_shared(&self.shared);
-        inner.server.close(channel_id);
-        inner.ready = false;
-        inner.surface_id = None;
-        inner.dvc_channel_id = None;
-        inner.supports_avc420 = false;
-    }
-
-    fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
-        tracing::info!(
-            channel_id,
-            payload_len = payload.len(),
-            first_bytes = ?&payload[..payload.len().min(32)],
-            "EGFX: incoming DVC payload"
-        );
-        let mut inner = lock_shared(&self.shared);
-
-        let was_ready = inner.ready;
-        let mut messages = inner.server.process(channel_id, payload)?;
-        tracing::trace!(
-            message_count = messages.len(),
-            "EGFX: server.process() returned messages"
-        );
-
-        // Sync our ready flag from the server's internal state.
-        inner.ready = inner.server.is_ready();
-        inner.supports_avc420 = inner.ready; // V8_1 with AVC420 was negotiated if ready
-
-        // On readiness transition: auto-create surface and map to output.
-        if !was_ready && inner.ready && inner.surface_id.is_none() {
+        // Auto-create surface on readiness if we have the server handle.
+        if inner.surface_id.is_none()
+            && let Some(handle) = inner.server_handle.clone()
+        {
             let width = inner.width;
             let height = inner.height;
+            let mut server = handle.lock().expect("GfxServerHandle mutex poisoned");
 
-            if let Some(surface_id) = inner.server.create_surface(width, height) {
-                inner.server.map_surface_to_output(surface_id, 0, 0);
+            if let Some(surface_id) = server.create_surface(width, height) {
+                server.map_surface_to_output(surface_id, 0, 0);
                 inner.surface_id = Some(surface_id);
                 tracing::info!(surface_id, width, height, "EGFX: auto-created surface");
 
-                // Append the CreateSurface + MapSurface PDUs to this response.
-                messages.extend(inner.server.drain_output());
+                // Drain the CreateSurface + MapSurface PDUs and send them.
+                let messages = dvc_to_svc_messages(server.drain_output());
+                drop(server);
+                Self::send_messages(&inner, messages);
             } else {
-                tracing::error!(width, height, "EGFX: failed to create surface, H.264 delivery disabled");
+                tracing::error!(
+                    width, height,
+                    "EGFX: failed to create surface, H.264 delivery disabled"
+                );
             }
         }
+    }
 
-        Ok(zgfx_wrap_messages(&messages))
+    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32) {
+        tracing::trace!(frame_id, queue_depth, "EGFX: frame acknowledged");
     }
 }
 
-impl DvcServerProcessor for EgfxBridge {}
+impl CosmicGfxHandler {
+    /// Send drained messages via the server event channel.
+    fn send_messages(inner: &EgfxInner, messages: Vec<SvcMessage>) {
+        if messages.is_empty() {
+            return;
+        }
+        if let Some(ref event_tx) = inner.event_tx {
+            let _ = event_tx.send(ServerEvent::Egfx(EgfxServerMessage::SendMessages {
+                messages,
+            }));
+        }
+    }
+}
 
 // --------------- Controller (public handle) ---------------
 
 /// Public handle for the display handler to query EGFX state and send
 /// H.264 frames through the DVC channel.
-///
-/// The server event sender is stored in the shared `EgfxInner` state,
-/// so it can be set via [`EgfxEventSetter`] after `RdpServer` construction
-/// while the controller has already been moved into the display handler.
 ///
 /// Cloning is cheap (wraps `Arc<Mutex<..>>`), allowing the controller
 /// to be shared between `LiveDisplay` (for `request_layout`) and
@@ -294,19 +165,18 @@ pub struct EgfxController {
 impl EgfxController {
     /// Reset EGFX state for a new RDP connection.
     ///
-    /// ironrdp-server does not always call `DvcProcessor::close()` when a
-    /// client disconnects, leaving stale `ready` / `supports_avc420` flags.
-    /// Call this when acquiring display channels for a new connection so the
-    /// EGFX handshake starts fresh.
+    /// Upstream's `GfxDvcBridge` handles DVC lifecycle, but we need to
+    /// reset our own tracking state (ready flag, surface ID, etc.)
+    /// when a new client connects.
     pub fn reset(&self) {
         let mut inner = lock_shared(&self.shared);
-        // Create a fresh pipeline server to avoid stale surfaces/frame IDs.
-        inner.server = GraphicsPipelineServer::new(Box::new(ReadyDetectHandler));
         inner.ready = false;
         inner.surface_id = None;
-        inner.dvc_channel_id = None;
         inner.supports_avc420 = false;
         inner.needs_keyframe = false;
+        // The GraphicsPipelineServer is recreated by the factory for each
+        // connection (via build_server_with_handle), so we just clear our handle.
+        inner.server_handle = None;
         tracing::debug!("EGFX: state reset for new connection");
     }
 
@@ -336,7 +206,7 @@ impl EgfxController {
     ///
     /// Locks the shared state, calls `send_avc420_frame` on the
     /// `GraphicsPipelineServer`, drains the output PDUs, and sends
-    /// them via the `ServerEvent::DvcOutput` channel.
+    /// them via `ServerEvent::Egfx`.
     ///
     /// Returns `true` if the frame was queued successfully, `false` if
     /// the channel is not ready, backpressure is active, or the event
@@ -349,20 +219,25 @@ impl EgfxController {
         height: u16,
         timestamp_ms: u32,
     ) -> bool {
-        let mut inner = lock_shared(&self.shared);
+        let inner = lock_shared(&self.shared);
 
         let Some(ref event_tx) = inner.event_tx else {
             tracing::warn!("EGFX: cannot send frame, event sender not configured");
             return false;
         };
-        // Clone sender before mutating inner state (borrow checker).
         let event_tx = event_tx.clone();
 
         let Some(surface_id) = inner.surface_id else {
             return false;
         };
 
-        if inner.server.should_backpressure() {
+        let Some(ref server_handle) = inner.server_handle else {
+            return false;
+        };
+
+        let mut server = server_handle.lock().expect("GfxServerHandle mutex poisoned");
+
+        if server.should_backpressure() {
             tracing::trace!("EGFX: backpressure active, dropping frame");
             return false;
         }
@@ -375,28 +250,22 @@ impl EgfxController {
         // (length-prefixed). Converting via annex_b_to_avc() causes
         // DecodeFrame2 to fail with state 0x0004.
         let Some(frame_id) =
-            inner
-                .server
-                .send_avc420_frame(surface_id, h264_data, &regions, timestamp_ms)
+            server.send_avc420_frame(surface_id, h264_data, &regions, timestamp_ms)
         else {
             return false;
         };
 
-        let drained = inner.server.drain_output();
-        let messages = zgfx_wrap_messages(&drained);
-        let Some(dvc_channel_id) = inner.dvc_channel_id else {
-            return false;
-        };
+        let messages = dvc_to_svc_messages(server.drain_output());
 
-        drop(inner); // Release lock before sending.
+        drop(server);
+        drop(inner);
 
-        tracing::trace!(frame_id, dvc_channel_id, "EGFX: sending H.264 frame");
+        tracing::trace!(frame_id, "EGFX: sending H.264 frame");
 
         if event_tx
-            .send(ServerEvent::DvcOutput {
-                dvc_channel_id,
+            .send(ServerEvent::Egfx(EgfxServerMessage::SendMessages {
                 messages,
-            })
+            }))
             .is_err()
         {
             tracing::warn!("EGFX: event channel closed, cannot send frame");
@@ -430,99 +299,87 @@ impl EgfxController {
         inner.height = height;
         inner.needs_keyframe = true;
 
-        inner.server.resize(width, height);
+        let Some(server_handle) = inner.server_handle.clone() else {
+            return;
+        };
 
-        if let Some(surface_id) = inner.server.create_surface(width, height) {
-            inner.server.map_surface_to_output(surface_id, 0, 0);
+        let mut server = server_handle.lock().expect("GfxServerHandle mutex poisoned");
+
+        server.resize(width, height);
+
+        if let Some(surface_id) = server.create_surface(width, height) {
+            server.map_surface_to_output(surface_id, 0, 0);
             inner.surface_id = Some(surface_id);
             tracing::info!(surface_id, width, height, "EGFX: resized surface");
         } else {
             tracing::error!(width, height, "EGFX: failed to create surface after resize");
         }
 
-        let drained = inner.server.drain_output();
-        let messages = zgfx_wrap_messages(&drained);
-        let Some(dvc_channel_id) = inner.dvc_channel_id else {
-            return;
-        };
+        let messages = dvc_to_svc_messages(server.drain_output());
 
+        drop(server);
         drop(inner);
 
-        let _ = event_tx.send(ServerEvent::DvcOutput {
-            dvc_channel_id,
+        let _ = event_tx.send(ServerEvent::Egfx(EgfxServerMessage::SendMessages {
             messages,
-        });
+        }));
     }
 }
 
-// --------------- Event Setter ---------------
+// --------------- GFX Factory ---------------
 
-/// Lightweight handle to set the server event sender in shared EGFX state.
+/// Factory that creates EGFX graphics pipeline components per connection.
 ///
-/// This is separated from [`EgfxController`] because the controller is
-/// moved into the display handler *before* the `RdpServer` is constructed,
-/// but the event sender is only available *after* construction.
-pub struct EgfxEventSetter {
+/// Implements [`GfxServerFactory`] (required by upstream's builder) and
+/// [`ServerEventSender`] (to receive the event channel after construction).
+pub struct CosmicGfxFactory {
     shared: SharedEgfx,
 }
 
-impl EgfxEventSetter {
-    /// Store the server event sender for proactive frame delivery.
-    pub fn set_event_sender(&self, sender: mpsc::UnboundedSender<ServerEvent>) {
+impl GfxServerFactory for CosmicGfxFactory {
+    fn build_gfx_handler(&self) -> Box<dyn GraphicsPipelineHandler> {
+        Box::new(CosmicGfxHandler {
+            shared: Arc::clone(&self.shared),
+        })
+    }
+
+    fn build_server_with_handle(&self) -> Option<(GfxDvcBridge, GfxServerHandle)> {
+        let handler = self.build_gfx_handler();
+        let server = GraphicsPipelineServer::new(handler);
+        let handle: GfxServerHandle = Arc::new(Mutex::new(server));
+        let bridge = GfxDvcBridge::new(Arc::clone(&handle));
+
+        // Store the handle so the controller can access it.
+        let mut inner = lock_shared(&self.shared);
+        inner.server_handle = Some(Arc::clone(&handle));
+
+        Some((bridge, handle))
+    }
+}
+
+impl ServerEventSender for CosmicGfxFactory {
+    fn set_sender(&mut self, sender: mpsc::UnboundedSender<ServerEvent>) {
         let mut inner = lock_shared(&self.shared);
         inner.event_tx = Some(sender);
         tracing::info!("EGFX: event sender configured");
     }
 }
 
-// --------------- Bridge Factory ---------------
-
-/// Factory that creates fresh [`EgfxBridge`] instances per RDP connection.
-///
-/// All bridges share the same `SharedEgfx` state (which is reset by
-/// [`EgfxController::reset()`] between connections), allowing the
-/// [`EgfxController`] and [`EgfxEventSetter`] to remain valid.
-pub struct EgfxBridgeFactory {
-    shared: SharedEgfx,
-}
-
-impl DvcProcessorFactory for EgfxBridgeFactory {
-    fn build(&self) -> Box<dyn DvcProcessor> {
-        tracing::debug!("EGFX: creating fresh bridge for new connection");
-        Box::new(EgfxBridge {
-            shared: Arc::clone(&self.shared),
-        })
-    }
-
-    #[allow(clippy::unnecessary_literal_bound)]
-    fn channel_name(&self) -> &str {
-        "Microsoft::Windows::RDS::Graphics"
-    }
-}
-
-// --------------- Factory ---------------
+// --------------- Public Factory Function ---------------
 
 /// Create the EGFX components.
 ///
 /// Returns:
-/// - An `EgfxBridgeFactory` to register with `RdpServer::add_dvc_factory`
-/// - An `EgfxController` for the display handler to send frames
-/// - An `EgfxEventSetter` to inject the server event sender after construction
+/// - A [`CosmicGfxFactory`] to pass to `RdpServer::builder().with_gfx_factory()`
+/// - An [`EgfxController`] for the display handler to send frames
 ///
-/// The factory creates a fresh [`EgfxBridge`] for each RDP connection,
-/// solving the issue where `drain(..)` in `attach_channels` consumed the
-/// bridge after the first connection.
-pub fn create_egfx(
-    width: u16,
-    height: u16,
-) -> (EgfxBridgeFactory, EgfxController, EgfxEventSetter) {
-    let server = GraphicsPipelineServer::new(Box::new(ReadyDetectHandler));
-
+/// The factory creates a fresh `GfxDvcBridge` + `GraphicsPipelineServer` for
+/// each RDP connection via [`GfxServerFactory::build_server_with_handle()`].
+pub fn create_egfx(width: u16, height: u16) -> (CosmicGfxFactory, EgfxController) {
     let shared: SharedEgfx = Arc::new(Mutex::new(EgfxInner {
-        server,
+        server_handle: None,
         ready: false,
         surface_id: None,
-        dvc_channel_id: None,
         supports_avc420: false,
         width,
         height,
@@ -530,35 +387,13 @@ pub fn create_egfx(
         needs_keyframe: false,
     }));
 
-    let factory = EgfxBridgeFactory {
+    let factory = CosmicGfxFactory {
         shared: Arc::clone(&shared),
     };
 
-    let controller = EgfxController {
-        shared: Arc::clone(&shared),
-    };
+    let controller = EgfxController { shared };
 
-    let event_setter = EgfxEventSetter { shared };
-
-    (factory, controller, event_setter)
-}
-
-/// Minimal handler that does nothing — readiness is detected by the
-/// bridge checking `server.is_ready()` after each `process()` call.
-struct ReadyDetectHandler;
-
-impl GraphicsPipelineHandler for ReadyDetectHandler {
-    fn capabilities_advertise(&mut self, _pdu: &CapabilitiesAdvertisePdu) {
-        tracing::debug!("EGFX: client advertised capabilities");
-    }
-
-    fn on_ready(&mut self, negotiated: &CapabilitySet) {
-        tracing::info!(?negotiated, "EGFX: channel ready (handler callback)");
-    }
-
-    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32) {
-        tracing::trace!(frame_id, queue_depth, "EGFX: frame acknowledged");
-    }
+    (factory, controller)
 }
 
 #[cfg(test)]
@@ -567,14 +402,8 @@ mod tests {
 
     #[test]
     fn create_egfx_returns_factory_and_controller() {
-        let (factory, controller, _setter) = create_egfx(1920, 1080);
-        let bridge = factory.build();
-        assert_eq!(bridge.channel_name(), "Microsoft::Windows::RDS::Graphics");
+        let (_factory, controller) = create_egfx(1920, 1080);
         assert!(!controller.is_ready());
         assert!(!controller.supports_avc420());
-
-        // Factory can create multiple bridges (one per connection).
-        let bridge2 = factory.build();
-        assert_eq!(bridge2.channel_name(), "Microsoft::Windows::RDS::Graphics");
     }
 }

--- a/crates/cosmic-ext-rdp-server/src/main.rs
+++ b/crates/cosmic-ext-rdp-server/src/main.rs
@@ -112,13 +112,12 @@ async fn main() -> Result<()> {
 
         let result = if cfg.static_display {
             tracing::info!("Using static display with EGFX color test pattern");
-            let (egfx_factory, egfx_controller, egfx_event_setter) =
+            let (egfx_factory, egfx_controller) =
                 egfx::create_egfx(1920, 1080);
             let rdp_server = server::build_server(
                 cfg.bind, &tls_ctx, auth.as_ref(), make_cliprdr(), make_sound(),
                 Some(Box::new(egfx_factory)),
             );
-            egfx_event_setter.set_event_sender(rdp_server.event_sender().clone());
             // Spawn background H.264 encoding task that sends a color test
             // pattern (RGBW quadrants) via EGFX when the client negotiates
             // AVC420. This allows testing the full encode→decode color
@@ -256,7 +255,7 @@ async fn run_live_or_fallback(
             let mut live_display = server::LiveDisplay::new(event_rx, &desktop_info);
 
             // Create EGFX components for H.264 delivery via DVC.
-            let (egfx_factory, egfx_controller, egfx_event_setter) =
+            let (egfx_factory, egfx_controller) =
                 egfx::create_egfx(desktop_info.width, desktop_info.height);
             live_display.set_egfx(egfx_controller);
 
@@ -280,21 +279,17 @@ async fn run_live_or_fallback(
                 cfg.bind, tls_ctx, auth, live_display, input_handler,
                 make_cliprdr(), make_sound(), Some(Box::new(egfx_factory)),
             );
-            // Set the event sender so the EGFX controller can push
-            // H.264 frames proactively via ServerEvent::DvcOutput.
-            egfx_event_setter.set_event_sender(rdp_server.event_sender().clone());
             let _capture = capture_handle;
             run_with_shutdown(rdp_server, dbus_cmd_rx).await
         }
         Err(e) => {
             tracing::warn!("Failed to start screen capture: {e:#}");
             tracing::info!("Falling back to static blue screen display");
-            let (egfx_factory, _egfx_controller, egfx_event_setter) =
+            let (egfx_factory, _egfx_controller) =
                 egfx::create_egfx(1920, 1080);
             let rdp_server =
                 server::build_server(cfg.bind, tls_ctx, auth, make_cliprdr(), make_sound(),
                     Some(Box::new(egfx_factory)));
-            egfx_event_setter.set_event_sender(rdp_server.event_sender().clone());
             run_with_shutdown(rdp_server, dbus_cmd_rx).await
         }
     }
@@ -489,11 +484,11 @@ fn save_restore_token(token: &str) {
     let Some(path) = restore_token_path() else {
         return;
     };
-    if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            tracing::warn!("Failed to create restore token dir: {e}");
-            return;
-        }
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        tracing::warn!("Failed to create restore token dir: {e}");
+        return;
     }
     if let Err(e) = std::fs::write(&path, token) {
         tracing::warn!("Failed to save restore token: {e}");

--- a/crates/cosmic-ext-rdp-server/src/server.rs
+++ b/crates/cosmic-ext-rdp-server/src/server.rs
@@ -7,9 +7,9 @@ use ironrdp_displaycontrol::pdu::DisplayControlMonitorLayout;
 use ironrdp_pdu::input::fast_path::SynchronizeFlags;
 use ironrdp_pdu::pointer::PointerPositionAttribute;
 use ironrdp_server::{
-    BitmapUpdate, CliprdrServerFactory, DesktopSize, DisplayUpdate, KeyboardEvent, MouseEvent,
-    PixelFormat, RGBAPointer, RdpServer, RdpServerDisplay, RdpServerDisplayUpdates,
-    RdpServerInputHandler, SoundServerFactory,
+    BitmapUpdate, CliprdrServerFactory, DesktopSize, DisplayUpdate, GfxServerFactory,
+    KeyboardEvent, MouseEvent, PixelFormat, RGBAPointer, RdpServer, RdpServerDisplay,
+    RdpServerDisplayUpdates, RdpServerInputHandler, SoundServerFactory,
 };
 use rdp_capture::{CaptureEvent, CapturedFrame, CursorInfo, DesktopInfo};
 use rdp_encode::{EncoderConfig, GstEncoder};
@@ -375,18 +375,18 @@ impl RdpServerDisplay for LiveDisplay {
         // Route resize through EGFX ResetGraphics instead of
         // DisplayUpdate::Resize to avoid ironrdp-server 0.10's broken
         // deactivation-reactivation sequence.
-        if let Some(ref egfx) = self.egfx {
-            if egfx.is_ready() {
-                tracing::info!(
-                    width, height,
-                    old_width = self.width, old_height = self.height,
-                    "Resizing display via EGFX ResetGraphics"
-                );
-                egfx.resize(width, height);
-                self.width = width;
-                self.height = height;
-                return;
-            }
+        if let Some(ref egfx) = self.egfx
+            && egfx.is_ready()
+        {
+            tracing::info!(
+                width, height,
+                old_width = self.width, old_height = self.height,
+                "Resizing display via EGFX ResetGraphics"
+            );
+            egfx.resize(width, height);
+            self.width = width;
+            self.height = height;
+            return;
         }
 
         // EGFX not available or not ready — cannot resize safely.
@@ -617,6 +617,7 @@ fn cursor_to_display_update(cursor: &CursorInfo) -> DisplayUpdate {
     if let Some(ref bitmap) = cursor.bitmap {
         #[allow(clippy::cast_possible_truncation)]
         DisplayUpdate::RGBAPointer(RGBAPointer {
+            cache_index: 0,
             width: bitmap.width as u16,
             height: bitmap.height as u16,
             hot_x: bitmap.hot_x as u16,
@@ -692,7 +693,7 @@ pub fn build_server(
     auth: Option<&AuthCredentials>,
     cliprdr: Option<Box<dyn CliprdrServerFactory>>,
     sound: Option<Box<dyn SoundServerFactory>>,
-    egfx_factory: Option<Box<dyn ironrdp_dvc::DvcProcessorFactory>>,
+    gfx_factory: Option<Box<dyn GfxServerFactory>>,
 ) -> RdpServer {
     let builder = RdpServer::builder().with_addr(bind_addr);
     let builder = with_security!(builder, tls, auth);
@@ -701,19 +702,17 @@ pub fn build_server(
         .with_display_handler(StaticDisplay::default())
         .with_cliprdr_factory(cliprdr)
         .with_sound_factory(sound)
+        .with_gfx_factory(gfx_factory)
         .build();
     apply_credentials(&mut server, auth);
-    if let Some(factory) = egfx_factory {
-        server.add_dvc_factory(factory);
-    }
     server
 }
 
 /// Build an RDP server with live screen capture and input injection.
 ///
-/// If `egfx_factory` is provided, it is registered as a DVC processor factory
-/// for EGFX/H.264 frame delivery through the DRDYNVC channel. A fresh
-/// processor is created for each RDP connection.
+/// If `gfx_factory` is provided, it is registered via the builder for
+/// EGFX/H.264 frame delivery through the DRDYNVC channel. A fresh
+/// `GfxDvcBridge` is created for each RDP connection.
 #[allow(clippy::too_many_arguments)]
 pub fn build_live_server(
     bind_addr: std::net::SocketAddr,
@@ -723,7 +722,7 @@ pub fn build_live_server(
     input_handler: LiveInputHandler,
     cliprdr: Option<Box<dyn CliprdrServerFactory>>,
     sound: Option<Box<dyn SoundServerFactory>>,
-    egfx_factory: Option<Box<dyn ironrdp_dvc::DvcProcessorFactory>>,
+    gfx_factory: Option<Box<dyn GfxServerFactory>>,
 ) -> RdpServer {
     let builder = RdpServer::builder().with_addr(bind_addr);
     let builder = with_security!(builder, tls, auth);
@@ -732,11 +731,9 @@ pub fn build_live_server(
         .with_display_handler(display)
         .with_cliprdr_factory(cliprdr)
         .with_sound_factory(sound)
+        .with_gfx_factory(gfx_factory)
         .build();
     apply_credentials(&mut server, auth);
-    if let Some(factory) = egfx_factory {
-        server.add_dvc_factory(factory);
-    }
     server
 }
 

--- a/crates/cosmic-ext-rdp-settings/src/app.rs
+++ b/crates/cosmic-ext-rdp-settings/src/app.rs
@@ -111,18 +111,18 @@ impl App {
         if let Err(_e) = self.fps.parse::<u32>() {
             return Some("FPS must be a positive number".to_string());
         }
-        if let Ok(fps) = self.fps.parse::<u32>() {
-            if fps == 0 || fps > 240 {
-                return Some("FPS must be between 1 and 240".to_string());
-            }
+        if let Ok(fps) = self.fps.parse::<u32>()
+            && (fps == 0 || fps > 240)
+        {
+            return Some("FPS must be between 1 and 240".to_string());
         }
         if let Err(_e) = self.bitrate_mbps.parse::<f64>() {
             return Some("Bitrate must be a number (Mbps)".to_string());
         }
-        if let Ok(mbps) = self.bitrate_mbps.parse::<f64>() {
-            if mbps <= 0.0 || mbps > 100.0 {
-                return Some("Bitrate must be between 0.1 and 100 Mbps".to_string());
-            }
+        if let Ok(mbps) = self.bitrate_mbps.parse::<f64>()
+            && (mbps <= 0.0 || mbps > 100.0)
+        {
+            return Some("Bitrate must be between 0.1 and 100 Mbps".to_string());
         }
         if let Err(_e) = self.buffer_capacity.parse::<usize>() {
             return Some("Buffer capacity must be a positive number".to_string());

--- a/crates/rdp-capture/src/compositor.rs
+++ b/crates/rdp-capture/src/compositor.rs
@@ -157,13 +157,11 @@ impl FrameCompositor {
                 }
             }
 
-            if any_new {
-                // Compose all latest frames into a single canvas.
-                if let Some(composed) = self.compose(&latest_frames) {
-                    if self.output_tx.try_send(CaptureEvent::Frame(composed)).is_err() {
-                        tracing::trace!("Compositor output channel full");
-                    }
-                }
+            if any_new
+                && let Some(composed) = self.compose(&latest_frames)
+                && self.output_tx.try_send(CaptureEvent::Frame(composed)).is_err()
+            {
+                tracing::trace!("Compositor output channel full");
             }
 
             // Sleep briefly to avoid busy-waiting.

--- a/crates/rdp-capture/src/pipewire_stream.rs
+++ b/crates/rdp-capture/src/pipewire_stream.rs
@@ -125,11 +125,11 @@ fn run_pipewire_loop(
                 // Parse the format pod to extract the negotiated video format.
                 if let Ok((_, pw::spa::pod::Value::Object(obj))) = pw::spa::pod::deserialize::PodDeserializer::deserialize_any_from(pod.as_bytes()) {
                     for prop in &obj.properties {
-                        if prop.key == pw::spa::param::format::FormatProperties::VideoFormat.as_raw() {
-                            if let pw::spa::pod::Value::Id(fmt_id) = prop.value {
-                                negotiated_format_cb.store(fmt_id.0, Ordering::SeqCst);
-                                tracing::info!(format_id = fmt_id.0, "PipeWire negotiated video format");
-                            }
+                        if prop.key == pw::spa::param::format::FormatProperties::VideoFormat.as_raw()
+                            && let pw::spa::pod::Value::Id(fmt_id) = prop.value
+                        {
+                            negotiated_format_cb.store(fmt_id.0, Ordering::SeqCst);
+                            tracing::info!(format_id = fmt_id.0, "PipeWire negotiated video format");
                         }
                     }
                 }

--- a/crates/rdp-capture/src/spa_meta.rs
+++ b/crates/rdp-capture/src/spa_meta.rs
@@ -31,58 +31,61 @@ pub unsafe fn extract_damage(
         return None;
     }
 
-    let buffer = &*spa_buffer;
-    if buffer.n_metas == 0 || buffer.metas.is_null() {
-        return None;
-    }
-
-    let metas = std::slice::from_raw_parts(buffer.metas, buffer.n_metas as usize);
-
-    for meta in metas {
-        if meta.type_ != spa_sys::SPA_META_VideoDamage {
-            continue;
-        }
-
-        if meta.data.is_null() || meta.size == 0 {
+    // SAFETY: caller guarantees spa_buffer is valid for the duration of this call.
+    unsafe {
+        let buffer = &*spa_buffer;
+        if buffer.n_metas == 0 || buffer.metas.is_null() {
             return None;
         }
 
-        let region_size = std::mem::size_of::<spa_sys::spa_meta_region>();
-        let max_regions = meta.size as usize / region_size;
+        let metas = std::slice::from_raw_parts(buffer.metas, buffer.n_metas as usize);
 
-        if max_regions == 0 {
-            return None;
-        }
-
-        let regions = meta.data.cast::<spa_sys::spa_meta_region>();
-        let mut damage_rects = Vec::new();
-
-        for i in 0..max_regions {
-            let region = &*regions.add(i);
-            let w = region.region.size.width;
-            let h = region.region.size.height;
-
-            // Zero-size region marks end of array (per SPA spec).
-            if w == 0 && h == 0 {
-                break;
+        for meta in metas {
+            if meta.type_ != spa_sys::SPA_META_VideoDamage {
+                continue;
             }
 
-            damage_rects.push(DamageRect::new(
-                region.region.position.x,
-                region.region.position.y,
-                w,
-                h,
-            ));
+            if meta.data.is_null() || meta.size == 0 {
+                return None;
+            }
+
+            let region_size = std::mem::size_of::<spa_sys::spa_meta_region>();
+            let max_regions = meta.size as usize / region_size;
+
+            if max_regions == 0 {
+                return None;
+            }
+
+            let regions = meta.data.cast::<spa_sys::spa_meta_region>();
+            let mut damage_rects = Vec::new();
+
+            for i in 0..max_regions {
+                let region = &*regions.add(i);
+                let w = region.region.size.width;
+                let h = region.region.size.height;
+
+                // Zero-size region marks end of array (per SPA spec).
+                if w == 0 && h == 0 {
+                    break;
+                }
+
+                damage_rects.push(DamageRect::new(
+                    region.region.position.x,
+                    region.region.position.y,
+                    w,
+                    h,
+                ));
+            }
+
+            tracing::trace!(
+                count = damage_rects.len(),
+                "Extracted damage rects from PipeWire metadata"
+            );
+            return Some(damage_rects);
         }
 
-        tracing::trace!(
-            count = damage_rects.len(),
-            "Extracted damage rects from PipeWire metadata"
-        );
-        return Some(damage_rects);
+        None
     }
-
-    None
 }
 
 /// Extract cursor metadata from a `PipeWire` buffer's `SPA_META_Cursor` metadata.
@@ -105,47 +108,50 @@ pub unsafe fn extract_cursor(
         return None;
     }
 
-    let buffer = &*spa_buffer;
-    if buffer.n_metas == 0 || buffer.metas.is_null() {
-        return None;
-    }
-
-    let metas = std::slice::from_raw_parts(buffer.metas, buffer.n_metas as usize);
-
-    for meta in metas {
-        if meta.type_ != spa_sys::SPA_META_Cursor {
-            continue;
-        }
-
-        if meta.data.is_null()
-            || (meta.size as usize) < std::mem::size_of::<spa_sys::spa_meta_cursor>()
-        {
+    // SAFETY: caller guarantees spa_buffer is valid for the duration of this call.
+    unsafe {
+        let buffer = &*spa_buffer;
+        if buffer.n_metas == 0 || buffer.metas.is_null() {
             return None;
         }
 
-        let cursor = &*(meta.data.cast::<spa_sys::spa_meta_cursor>());
+        let metas = std::slice::from_raw_parts(buffer.metas, buffer.n_metas as usize);
 
-        // id == 0 means no cursor data (cursor left the captured region).
-        if cursor.id == 0 {
+        for meta in metas {
+            if meta.type_ != spa_sys::SPA_META_Cursor {
+                continue;
+            }
+
+            if meta.data.is_null()
+                || (meta.size as usize) < std::mem::size_of::<spa_sys::spa_meta_cursor>()
+            {
+                return None;
+            }
+
+            let cursor = &*(meta.data.cast::<spa_sys::spa_meta_cursor>());
+
+            // id == 0 means no cursor data (cursor left the captured region).
+            if cursor.id == 0 {
+                return Some(CursorInfo {
+                    x: cursor.position.x,
+                    y: cursor.position.y,
+                    visible: false,
+                    bitmap: None,
+                });
+            }
+
+            let bitmap = extract_cursor_bitmap(meta.data, cursor);
+
             return Some(CursorInfo {
                 x: cursor.position.x,
                 y: cursor.position.y,
-                visible: false,
-                bitmap: None,
+                visible: true,
+                bitmap,
             });
         }
 
-        let bitmap = extract_cursor_bitmap(meta.data, cursor);
-
-        return Some(CursorInfo {
-            x: cursor.position.x,
-            y: cursor.position.y,
-            visible: true,
-            bitmap,
-        });
+        None
     }
-
-    None
 }
 
 /// Extract the cursor bitmap from a `spa_meta_cursor`, if present.
@@ -169,68 +175,72 @@ unsafe fn extract_cursor_bitmap(
         return None;
     }
 
-    #[allow(clippy::cast_ptr_alignment)] // SPA guarantees 4-byte aligned metadata
-    let bitmap_ptr = meta_data
-        .cast::<u8>()
-        .add(cursor.bitmap_offset as usize)
-        .cast::<spa_sys::spa_meta_bitmap>();
-    let bitmap = &*bitmap_ptr;
+    // SAFETY: caller guarantees meta_data points to valid memory with
+    // sufficient size for the bitmap offset and spa_meta_bitmap struct.
+    unsafe {
+        #[allow(clippy::cast_ptr_alignment)] // SPA guarantees 4-byte aligned metadata
+        let bitmap_ptr = meta_data
+            .cast::<u8>()
+            .add(cursor.bitmap_offset as usize)
+            .cast::<spa_sys::spa_meta_bitmap>();
+        let bitmap = &*bitmap_ptr;
 
-    // offset == 0 in the bitmap means no pixel data (invisible cursor).
-    if bitmap.offset == 0 {
-        return None;
-    }
+        // offset == 0 in the bitmap means no pixel data (invisible cursor).
+        if bitmap.offset == 0 {
+            return None;
+        }
 
-    let width = bitmap.size.width;
-    let height = bitmap.size.height;
+        let width = bitmap.size.width;
+        let height = bitmap.size.height;
 
-    if width == 0 || height == 0 {
-        return None;
-    }
+        if width == 0 || height == 0 {
+            return None;
+        }
 
-    // Validate format: we only handle ARGB8888.
-    if bitmap.format != spa_sys::SPA_VIDEO_FORMAT_ARGB {
-        tracing::debug!(
-            format = bitmap.format,
-            "Unsupported cursor bitmap format (expected ARGB8888)"
-        );
-        return None;
-    }
+        // Validate format: we only handle ARGB8888.
+        if bitmap.format != spa_sys::SPA_VIDEO_FORMAT_ARGB {
+            tracing::debug!(
+                format = bitmap.format,
+                "Unsupported cursor bitmap format (expected ARGB8888)"
+            );
+            return None;
+        }
 
-    let stride = bitmap.stride.unsigned_abs() as usize;
-    let expected_size = stride * height as usize;
+        let stride = bitmap.stride.unsigned_abs() as usize;
+        let expected_size = stride * height as usize;
 
-    // Read pixel data from the bitmap's offset field.
-    let pixel_ptr = bitmap_ptr
-        .cast::<u8>()
-        .add(bitmap.offset as usize);
-    let pixel_data = std::slice::from_raw_parts(pixel_ptr, expected_size);
+        // Read pixel data from the bitmap's offset field.
+        let pixel_ptr = bitmap_ptr
+            .cast::<u8>()
+            .add(bitmap.offset as usize);
+        let pixel_data = std::slice::from_raw_parts(pixel_ptr, expected_size);
 
-    // Convert ARGB8888 (A,R,G,B on big-endian / B,G,R,A on little-endian)
-    // to RGBA. On little-endian (x86), the memory layout for ARGB is
-    // [B, G, R, A] and we need [R, G, B, A].
-    let mut rgba = Vec::with_capacity(width as usize * height as usize * 4);
-    for row in 0..height as usize {
-        let row_start = row * stride;
-        for col in 0..width as usize {
-            let px = row_start + col * 4;
-            if px + 3 < pixel_data.len() {
-                // ARGB on LE: [B, G, R, A] -> RGBA: [R, G, B, A]
-                rgba.push(pixel_data[px + 2]); // R
-                rgba.push(pixel_data[px + 1]); // G
-                rgba.push(pixel_data[px]);     // B
-                rgba.push(pixel_data[px + 3]); // A
+        // Convert ARGB8888 (A,R,G,B on big-endian / B,G,R,A on little-endian)
+        // to RGBA. On little-endian (x86), the memory layout for ARGB is
+        // [B, G, R, A] and we need [R, G, B, A].
+        let mut rgba = Vec::with_capacity(width as usize * height as usize * 4);
+        for row in 0..height as usize {
+            let row_start = row * stride;
+            for col in 0..width as usize {
+                let px = row_start + col * 4;
+                if px + 3 < pixel_data.len() {
+                    // ARGB on LE: [B, G, R, A] -> RGBA: [R, G, B, A]
+                    rgba.push(pixel_data[px + 2]); // R
+                    rgba.push(pixel_data[px + 1]); // G
+                    rgba.push(pixel_data[px]);     // B
+                    rgba.push(pixel_data[px + 3]); // A
+                }
             }
         }
-    }
 
-    Some(CursorBitmap {
-        width,
-        height,
-        hot_x: cursor.hotspot.x.max(0) as u32,
-        hot_y: cursor.hotspot.y.max(0) as u32,
-        data: rgba,
-    })
+        Some(CursorBitmap {
+            width,
+            height,
+            hot_x: cursor.hotspot.x.max(0) as u32,
+            hot_y: cursor.hotspot.y.max(0) as u32,
+            data: rgba,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/rdp-encode/src/gstreamer_enc.rs
+++ b/crates/rdp-encode/src/gstreamer_enc.rs
@@ -187,23 +187,23 @@ impl GstEncoder {
         // negotiation. Caps may not be available until after the first
         // encoded frame is pulled, so only mark as logged when we
         // actually see caps (retry on subsequent frames otherwise).
-        if !self.caps_logged {
-            if let Some(convert) = self.pipeline.by_name("convert") {
-                let sink_caps = convert.static_pad("sink").and_then(|p| p.current_caps());
-                let src_caps = convert.static_pad("src").and_then(|p| p.current_caps());
-                if sink_caps.is_some() || src_caps.is_some() {
-                    self.caps_logged = true;
-                    if let Some(caps) = sink_caps {
-                        tracing::info!(%caps, "videoconvert input caps (negotiated)");
-                    }
-                    if let Some(caps) = src_caps {
-                        tracing::info!(%caps, "videoconvert output caps (negotiated)");
-                    }
-                    if let Some(enc) = self.pipeline.by_name("encoder") {
-                        if let Some(caps) = enc.static_pad("sink").and_then(|p| p.current_caps()) {
-                            tracing::info!(%caps, "encoder input caps (negotiated)");
-                        }
-                    }
+        if !self.caps_logged
+            && let Some(convert) = self.pipeline.by_name("convert")
+        {
+            let sink_caps = convert.static_pad("sink").and_then(|p| p.current_caps());
+            let src_caps = convert.static_pad("src").and_then(|p| p.current_caps());
+            if sink_caps.is_some() || src_caps.is_some() {
+                self.caps_logged = true;
+                if let Some(caps) = sink_caps {
+                    tracing::info!(%caps, "videoconvert input caps (negotiated)");
+                }
+                if let Some(caps) = src_caps {
+                    tracing::info!(%caps, "videoconvert output caps (negotiated)");
+                }
+                if let Some(enc) = self.pipeline.by_name("encoder")
+                    && let Some(caps) = enc.static_pad("sink").and_then(|p| p.current_caps())
+                {
+                    tracing::info!(%caps, "encoder input caps (negotiated)");
                 }
             }
         }

--- a/flake.nix
+++ b/flake.nix
@@ -177,7 +177,6 @@
           packages = buildDeps ++ nativeBuildDeps ++ guiNativeBuildDeps
             ++ runtimeDeps ++ guiRuntimeDeps ++ (with pkgs; [
             rust-analyzer
-            clippy
             rustfmt
             cargo-watch
             linux-pam


### PR DESCRIPTION
## Summary

- **Drop custom IronRDP fork** (`olafkfreund/cosmic-ext-IronRDP`) — upstream Devolutions/IronRDP now has native EGFX/AVC420 server support
- **Rewrite `egfx.rs`** (~580→330 lines): replace manual `DvcProcessorFactory`/ZGFX wrapping with upstream's `GfxServerFactory` API
- **Upgrade to Rust edition 2024** (MSRV 1.89): explicit `unsafe` blocks, let-chains for collapsible ifs
- **Fix dev shell toolchain mismatch**: remove standalone clippy package that conflicted with system rustc

## Test plan

- [x] `cargo check --workspace` — 0 errors, 0 warnings
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 30/30 tests pass
- [ ] Manual RDP connection test with FreeRDP/mstsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)